### PR TITLE
FaceViewerCLI now talks to CubeService

### DIFF
--- a/Solution/FaceViewerCLI/GetCubeStrategies/GetCubeViaAPIStrategy.cs
+++ b/Solution/FaceViewerCLI/GetCubeStrategies/GetCubeViaAPIStrategy.cs
@@ -1,0 +1,85 @@
+﻿using LibNetCube;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FaceViewerCLI.GetCubeStrategies
+{
+    internal class GetCubeViaAPIStrategy : IGetCubeStrategy
+    {
+        private string _serverAddress = "http://localhost:5295";
+        private static HttpClient Client = new HttpClient();
+
+        public CubeState? GetCube()
+        {
+            Task<CubeState?> task = GetCubeAsync();
+            task.Wait();
+
+            return task.Result;
+        }
+
+        private async Task<CubeState?> GetCubeAsync()
+        {
+            List<string> faces = ["Back", "Bottom", "Front", "Left", "Right", "Top"];
+            List<int[,]> faceMatrices = new List<int[,]>();
+
+            foreach (string face in faces)
+            {
+                int[,]? result = await GetFaceAsync(face);
+                if (result is int[,] matrix)
+                {
+                    faceMatrices.Add(matrix);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            if (faceMatrices.Count == 6)
+            {
+                return new CubeState(faceMatrices);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private async Task<int[,]?> GetFaceAsync(string face)
+        {
+            string requestUri = $"{_serverAddress}/api/Cube/Face?face={face}";
+            HttpResponseMessage response = await Client.GetAsync(requestUri);
+            string responseString = await response.Content.ReadAsStringAsync();
+            return ExtractFaceMatrix(responseString);
+        }
+
+        private int[,]? ExtractFaceMatrix(string response)
+        {
+            try
+            {
+                response = response.Substring(1, response.Length - 2);
+                string[] values = response.Split(',');
+                int[,] result = new int[3, 3];
+
+                int p = 0;
+                for (int i = 0; i < 3; i++)
+                {
+                    for (int j = 0; j < 3; j++)
+                    {
+                        result[i, j] = int.Parse(values[p++]);
+                    }
+                }
+
+                return result;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+    }
+}

--- a/Solution/FaceViewerCLI/GetCubeStrategies/GetCubeViaAPIStrategy.cs
+++ b/Solution/FaceViewerCLI/GetCubeStrategies/GetCubeViaAPIStrategy.cs
@@ -64,12 +64,12 @@ namespace FaceViewerCLI.GetCubeStrategies
                 string[] values = response.Split(',');
                 int[,] result = new int[3, 3];
 
-                int p = 0;
                 for (int i = 0; i < 3; i++)
                 {
                     for (int j = 0; j < 3; j++)
                     {
-                        result[i, j] = int.Parse(values[p++]);
+                        int p = (i*3) + j;
+                        result[i, j] = int.Parse(values[p]);
                     }
                 }
 

--- a/Solution/FaceViewerCLI/GetCubeStrategies/GetCubeViaSocketStrategy.cs
+++ b/Solution/FaceViewerCLI/GetCubeStrategies/GetCubeViaSocketStrategy.cs
@@ -1,0 +1,21 @@
+﻿using FaceViewerCLI.PerformMoveStrategies;
+using LibNetCube;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FaceViewerCLI.GetCubeStrategies
+{
+    internal class GetCubeViaSocketStrategy : IGetCubeStrategy
+    {
+        public CubeState? GetCube()
+        {
+            MoveViaSocketStrategy strategy = new MoveViaSocketStrategy();
+            CubeState? result = strategy.SendMoveRequest("X");
+
+            return result;
+        }
+    }
+}

--- a/Solution/FaceViewerCLI/GetCubeStrategies/IGetCubeStrategy.cs
+++ b/Solution/FaceViewerCLI/GetCubeStrategies/IGetCubeStrategy.cs
@@ -1,0 +1,14 @@
+﻿using LibNetCube;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FaceViewerCLI
+{
+    internal interface IGetCubeStrategy
+    {
+        public CubeState? GetCube();
+    }
+}

--- a/Solution/FaceViewerCLI/PerformMoveStrategies/IPerformMoveStrategy.cs
+++ b/Solution/FaceViewerCLI/PerformMoveStrategies/IPerformMoveStrategy.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FaceViewerCLI.PerformMoveStrategies
+{
+    internal interface IPerformMoveStrategy
+    {
+        public void PerformMove(string move);
+    }
+}

--- a/Solution/FaceViewerCLI/PerformMoveStrategies/MoveViaAPIStrategy.cs
+++ b/Solution/FaceViewerCLI/PerformMoveStrategies/MoveViaAPIStrategy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FaceViewerCLI.PerformMoveStrategies
+{
+    internal class MoveViaAPIStrategy : IPerformMoveStrategy
+    {
+        private string _serverAddress = "http://localhost:5295";
+        private static HttpClient Client = new HttpClient();
+
+        public void PerformMove(string move)
+        {
+            Task<bool> task = PerformMoveAsync(move);
+            task.Wait();
+            Console.WriteLine($"verdict: {task.Result}");
+        }
+
+        private async Task<bool> PerformMoveAsync(string move)
+        {
+            string requestUri = $"{_serverAddress}/api/Cube/PerformMove?move={move}";
+            HttpResponseMessage response = await Client.PostAsync(requestUri, null);
+            return response.IsSuccessStatusCode;
+        }
+    }
+}

--- a/Solution/FaceViewerCLI/PerformMoveStrategies/MoveViaSocketStrategy.cs
+++ b/Solution/FaceViewerCLI/PerformMoveStrategies/MoveViaSocketStrategy.cs
@@ -1,0 +1,60 @@
+﻿using LibNetCube;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FaceViewerCLI.PerformMoveStrategies
+{
+    internal class MoveViaSocketStrategy : IPerformMoveStrategy
+    {
+        private static readonly string _hostname = "127.0.0.1";
+        private static readonly int _port = 5000;
+        private static TcpClient Client = new TcpClient();
+
+        public void PerformMove(string move)
+        {
+            SendMoveRequest(move);
+        }
+
+        public CubeState? SendMoveRequest(string message)
+        {
+            try
+            {
+                Client.Connect(_hostname, _port);
+                NetworkStream nStream = Client.GetStream();
+
+                byte[] request = Serialize(message);
+                nStream.Write(request, 0, request.Length);
+
+                byte[] received = ReadFromStream(nStream);
+                return new CubeState(received);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public byte[] ReadFromStream(NetworkStream stream)
+        {
+            int messageLength = stream.ReadByte();
+            byte[] messageBytes = new byte[messageLength];
+            stream.Read(messageBytes, 0, messageLength);
+            return messageBytes;
+        }
+
+        public byte[] Serialize(string request)
+        {
+            byte[] responseBytes = Encoding.ASCII.GetBytes(request);
+            byte responseLength = (byte)responseBytes.Length;
+
+            byte[] rawData = new byte[responseLength + 1];
+            rawData[0] = responseLength;
+            responseBytes.CopyTo(rawData, 1);
+            return rawData;
+        }
+    }
+}

--- a/Solution/FaceViewerCLI/PerformMoveStrategies/MoveViaSocketStrategy.cs
+++ b/Solution/FaceViewerCLI/PerformMoveStrategies/MoveViaSocketStrategy.cs
@@ -12,7 +12,6 @@ namespace FaceViewerCLI.PerformMoveStrategies
     {
         private static readonly string _hostname = "127.0.0.1";
         private static readonly int _port = 5000;
-        private static TcpClient Client = new TcpClient();
 
         public void PerformMove(string move)
         {
@@ -23,13 +22,19 @@ namespace FaceViewerCLI.PerformMoveStrategies
         {
             try
             {
-                Client.Connect(_hostname, _port);
-                NetworkStream nStream = Client.GetStream();
+                TcpClient client = new TcpClient();
+
+                client.Connect(_hostname, _port);
+                NetworkStream nStream = client.GetStream();
 
                 byte[] request = Serialize(message);
                 nStream.Write(request, 0, request.Length);
 
                 byte[] received = ReadFromStream(nStream);
+
+                client.Close();
+                client.Dispose();
+
                 return new CubeState(received);
             }
             catch

--- a/Solution/FaceViewerCLI/Program.cs
+++ b/Solution/FaceViewerCLI/Program.cs
@@ -2,6 +2,8 @@
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
+using FaceViewerCLI.GetCubeStrategies;
+using FaceViewerCLI.PerformMoveStrategies;
 using LibNetCube;
 
 namespace FaceViewerCLI
@@ -9,59 +11,37 @@ namespace FaceViewerCLI
     internal class Program
     {
         private static FacePresenter Presenter = new FacePresenter();
+        private static CubeState CubeState = new CubeState(new CubePuzzle().GetState());
+
+        private static IPerformMoveStrategy PerformMoveStrategy = new MoveViaSocketStrategy();
+        private static IGetCubeStrategy GetCubeStrategy = new GetCubeViaSocketStrategy();
 
         static void Main(string[] args)
         {
             while (true)
             {
+                if (GetCubeStrategy.GetCube() is CubeState state)
+                {
+                    CubeState = state;
+                }
+                else
+                {
+                    Console.WriteLine("Lost connection to server.");
+                    Thread.Sleep(500);
+                    Console.WriteLine("Attempting to reconnect...");
+                    continue;
+                }
+
+                Presenter.PresentCube(CubeState);
+
                 Console.WriteLine("Enter a move to be performed...");
                 string? message = Console.ReadLine();
 
                 if (message != null)
                 {
-                    SendMoveRequest(message);
+                    PerformMoveStrategy.PerformMove(message);
                 }
             }
         }
-
-        static void SendMoveRequest(string message)
-        {
-            TcpClient tcpClient = new TcpClient();
-            tcpClient.Connect("127.0.0.1", 5000);
-
-            NetworkStream nStream = tcpClient.GetStream();
-
-            if (message != null)
-            {
-                byte[] request = Serialize(message);
-                nStream.Write(request, 0, request.Length);
-                // TODO: Read response from stream and display to user
-                byte[] received = ReadFromStream(nStream);
-
-                CubeState state = new CubeState(received);
-                Presenter.PresentCube(state);
-            }
-        }
-
-        static byte[] ReadFromStream(NetworkStream stream)
-        {
-            int messageLength = stream.ReadByte();
-            byte[] messageBytes = new byte[messageLength];
-            stream.Read(messageBytes, 0, messageLength);
-            return messageBytes;
-        }
-
-        static byte[] Serialize(string request)
-        {
-            byte[] responseBytes = Encoding.ASCII.GetBytes(request);
-            byte responseLength = (byte)responseBytes.Length;
-
-            byte[] rawData = new byte[responseLength + 1];
-            rawData[0] = responseLength;
-            responseBytes.CopyTo(rawData, 1);
-            return rawData;
-        }
-
-
     }
 }

--- a/Solution/FaceViewerCLI/Program.cs
+++ b/Solution/FaceViewerCLI/Program.cs
@@ -35,9 +35,7 @@ namespace FaceViewerCLI
                 Presenter.PresentCube(CubeState);
 
                 Console.WriteLine("Enter a move to be performed...");
-                string? message = Console.ReadLine();
-
-                if (message != null)
+                if (Console.ReadLine() is string message)
                 {
                     PerformMoveStrategy.PerformMove(message);
                 }

--- a/Solution/FaceViewerCLI/Program.cs
+++ b/Solution/FaceViewerCLI/Program.cs
@@ -13,8 +13,8 @@ namespace FaceViewerCLI
         private static FacePresenter Presenter = new FacePresenter();
         private static CubeState CubeState = new CubeState(new CubePuzzle().GetState());
 
-        private static IPerformMoveStrategy PerformMoveStrategy = new MoveViaSocketStrategy();
-        private static IGetCubeStrategy GetCubeStrategy = new GetCubeViaSocketStrategy();
+        private static IPerformMoveStrategy PerformMoveStrategy = new MoveViaAPIStrategy();
+        private static IGetCubeStrategy GetCubeStrategy = new GetCubeViaAPIStrategy();
 
         static void Main(string[] args)
         {


### PR DESCRIPTION
- ```FaceViewerCLI``` now talks to ```CubeService``` - a Web API
- the program can be edited to talk to the ```DummyService``` by changing the **IGetCubeStrategy** & **IPerformMoveStrategy** variables, seen below

![image](https://github.com/user-attachments/assets/e65b88e3-7037-40a4-a126-0c4376ed914b)

As shown below, the [Strategy Pattern](https://refactoring.guru/design-patterns/strategy) is now being used to simplify swapping between talking to ```CubeService``` and ```DummyService```.

#### Class Diagram

![image](https://github.com/user-attachments/assets/cfc42002-db90-43cc-8505-67487bd2d666)

These elements could be moved into a shared library and reused in the upcoming ```CubeProxy```. The elements could also be encapsulated in separate [Adapters](https://refactoring.guru/design-patterns/adapter) for ```CubeService``` and ```DummyService``` respectively.
