### PR TITLE
Fix: API rejecting {move}' and {move}2

### DIFF
--- a/Solution/CubeService/Controllers/CubeController.cs
+++ b/Solution/CubeService/Controllers/CubeController.cs
@@ -19,24 +19,35 @@ namespace CubeService.Controllers
         {
             return Ok();
         }
+
         [HttpPost("[action]")]
         public IActionResult ApplyShuffle([FromQuery] string? shuffle = null)
         {
             return Ok();
         }
+
         [HttpPost("[action]")]
         public IActionResult PerformMove([FromQuery] string? move = null)
         {
-            //attempt to parse move as Enum
-            if (String.IsNullOrEmpty(move) || !Enum.TryParse<CubeMove>(move, out var parsedMove))
+            if (move is string)
             {
-                //Not a valid move
-                return BadRequest();
+                try
+                {
+                    //attempt to parse move as Enum
+                    CubeMove parsedMove = MoveParser.ParseMove(move)!;
+                    _cubePuzzle.PerformMove(move);
+                    return Ok();
+                }
+                catch
+                {
+                    //Not a valid move
+                    return BadRequest();
+                }
             }
-            //Is a valid move
-            _cubePuzzle.PerformMove(move);
-            return Ok();
+
+            return BadRequest();
         }
+
         [HttpGet]
         [Route("")] //follows base route of api/[controller]
         [Route("[action]")]

--- a/Solution/LibNetCube/CubePuzzle.cs
+++ b/Solution/LibNetCube/CubePuzzle.cs
@@ -76,6 +76,7 @@
                 CubeMove baseMove = SimplifyComplexMove(move);
                 PerformMove(baseMove);
                 PerformMove(baseMove);
+                return;
             }
 
             if (IsPrimeMove(move))
@@ -84,12 +85,12 @@
                 PerformMove(baseMove);
                 PerformMove(baseMove);
                 PerformMove(baseMove);
+                return;
             }
-
-            CubeState state = GetState();
 
             if (move == CubeMove.M)
             {
+                CubeState state = GetState();
                 PuzzleRotation.RotateEntirePuzzle(state, "up");
                 SetState(state);
                 PerformMove(CubeMove.RPrime);
@@ -97,37 +98,18 @@
                 return;
             }
 
-            if (move == CubeMove.U)
-            {
-                FaceRotation.RotateFaceClockwise(state, CubeFace.Top);
-            }
+            List<CubeFace> faces = [CubeFace.Top, CubeFace.Bottom, CubeFace.Left, CubeFace.Right, CubeFace.Front, CubeFace.Back];
+            List<CubeMove> moves = [CubeMove.U, CubeMove.D, CubeMove.L, CubeMove.R, CubeMove.F, CubeMove.B];
 
-            if (move == CubeMove.D)
+            for(int i=0; i<6; i++)
             {
-                FaceRotation.RotateFaceClockwise(state, CubeFace.Bottom);
+                if (move == moves[i])
+                {
+                    CubeState state = GetState();
+                    FaceRotation.RotateFaceClockwise(state, faces[i]);
+                    SetState(state);
+                }
             }
-
-            if (move == CubeMove.L)
-            {
-                FaceRotation.RotateFaceClockwise(state, CubeFace.Left);
-            }
-
-            if (move == CubeMove.R)
-            {
-                FaceRotation.RotateFaceClockwise(state, CubeFace.Right);
-            }
-
-            if (move == CubeMove.F)
-            {
-                FaceRotation.RotateFaceClockwise(state, CubeFace.Front);
-            }
-
-            if (move == CubeMove.B)
-            {
-                FaceRotation.RotateFaceClockwise(state, CubeFace.Back);
-            }
-
-            SetState(state);
         }
 
         private bool IsTwoMove(CubeMove move)


### PR DESCRIPTION
- Previously, ```CubeService``` was rejecting complex moves due to Enum.TryParse being used - this is incompatible with cube notation e.g. ```R'```
- Now using **MoveParser** from ```LibCubeNet```, instead, allowing **{move}'** and **{move}2** moves to be performed
- Includes minor refactoring for **CubePuzzle**