### PR TITLE
feat: added working reset functionality to reset the state of the cube

### DIFF
--- a/Solution/CubeService/Controllers/CubeController.cs
+++ b/Solution/CubeService/Controllers/CubeController.cs
@@ -17,6 +17,7 @@ namespace CubeService.Controllers
         [HttpPost("[action]")]
         public IActionResult Reset()
         {
+            _cubePuzzle.Reset();
             return Ok();
         }
 

--- a/Solution/LibNetCube/CubePuzzle.cs
+++ b/Solution/LibNetCube/CubePuzzle.cs
@@ -13,6 +13,16 @@
         private int[,] FrontFace = { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
         private int[,] BackFace = { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
 
+        public void Reset()
+        {
+            TopFace = new int[,] { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
+            BottomFace = new int[,] { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+            LeftFace = new int[,] { { 3, 3, 3 }, { 3, 3, 3 }, { 3, 3, 3 } };
+            RightFace = new int[,] { { 4, 4, 4 }, { 4, 4, 4 }, { 4, 4, 4 } };
+            FrontFace = new int[,] { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
+            BackFace = new int[,] { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
+        }
+
         public CubeState GetState()
         {
             List<int[,]> reads = new List<int[,]>();

--- a/Solution/TestSuite/CubePuzzleTests.cs
+++ b/Solution/TestSuite/CubePuzzleTests.cs
@@ -79,4 +79,38 @@ public class CubePuzzleTests
         CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
         CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
     }
+
+    [TestMethod]
+    public void TestResetAfterSettingCustomState()
+    {
+        CubePuzzle puzzle = new CubePuzzle();
+
+        int[,] customTopFace = { { 6, 6, 6 }, { 6, 6, 6 }, { 6, 6, 6 } };
+        int[,] customBottomFace = { { 7, 7, 7 }, { 7, 7, 7 }, { 7, 7, 7 } };
+        int[,] customLeftFace = { { 8, 8, 8 }, { 8, 8, 8 }, { 8, 8, 8 } };
+        int[,] customRightFace = { { 9, 9, 9 }, { 9, 9, 9 }, { 9, 9, 9 } };
+        int[,] customFrontFace = { { 10, 10, 10 }, { 10, 10, 10 }, { 10, 10, 10 } };
+        int[,] customBackFace = { { 11, 11, 11 }, { 11, 11, 11 }, { 11, 11, 11 } };
+
+        List<int[,]> customFaces = new List<int[,]> { customTopFace, customBottomFace, customLeftFace, customRightFace, customFrontFace, customBackFace };
+        CubeState customState = new CubeState(customFaces);
+        puzzle.SetState(customState);
+
+        puzzle.Reset();
+        CubeState state = puzzle.GetState();
+
+        int[,] expectedTopFace = { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
+        int[,] expectedBottomFace = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+        int[,] expectedLeftFace = { { 3, 3, 3 }, { 3, 3, 3 }, { 3, 3, 3 } };
+        int[,] expectedRightFace = { { 4, 4, 4 }, { 4, 4, 4 }, { 4, 4, 4 } };
+        int[,] expectedFrontFace = { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
+        int[,] expectedBackFace = { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
+
+        CollectionAssert.AreEqual(expectedTopFace, state.GetFace(CubeFace.Top));
+        CollectionAssert.AreEqual(expectedBottomFace, state.GetFace(CubeFace.Bottom));
+        CollectionAssert.AreEqual(expectedLeftFace, state.GetFace(CubeFace.Left));
+        CollectionAssert.AreEqual(expectedRightFace, state.GetFace(CubeFace.Right));
+        CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
+        CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
+    }
 }

--- a/Solution/TestSuite/CubePuzzleTests.cs
+++ b/Solution/TestSuite/CubePuzzleTests.cs
@@ -29,4 +29,28 @@ public class CubePuzzleTests
         CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
         CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
     }
+
+    [TestMethod]
+    public void TestResetWithoutAnyMoves()
+    {
+        CubePuzzle puzzle = new CubePuzzle();
+
+        puzzle.Reset();
+        CubeState state = puzzle.GetState();
+
+        int[,] expectedTopFace = { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
+        int[,] expectedBottomFace = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+        int[,] expectedLeftFace = { { 3, 3, 3 }, { 3, 3, 3 }, { 3, 3, 3 } };
+        int[,] expectedRightFace = { { 4, 4, 4 }, { 4, 4, 4 }, { 4, 4, 4 } };
+        int[,] expectedFrontFace = { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
+        int[,] expectedBackFace = { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
+
+        CollectionAssert.AreEqual(expectedTopFace, state.GetFace(CubeFace.Top));
+        CollectionAssert.AreEqual(expectedBottomFace, state.GetFace(CubeFace.Bottom));
+        CollectionAssert.AreEqual(expectedLeftFace, state.GetFace(CubeFace.Left));
+        CollectionAssert.AreEqual(expectedRightFace, state.GetFace(CubeFace.Right));
+        CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
+        CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
+    }
+
 }

--- a/Solution/TestSuite/CubePuzzleTests.cs
+++ b/Solution/TestSuite/CubePuzzleTests.cs
@@ -29,4 +29,27 @@ public class CubePuzzleTests
         CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
         CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
     }
+
+    [TestMethod]
+    public void TestResetWithoutAnyMoves()
+    {
+        CubePuzzle puzzle = new CubePuzzle();
+
+        puzzle.Reset();
+        CubeState state = puzzle.GetState();
+
+        int[,] expectedTopFace = { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
+        int[,] expectedBottomFace = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+        int[,] expectedLeftFace = { { 3, 3, 3 }, { 3, 3, 3 }, { 3, 3, 3 } };
+        int[,] expectedRightFace = { { 4, 4, 4 }, { 4, 4, 4 }, { 4, 4, 4 } };
+        int[,] expectedFrontFace = { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
+        int[,] expectedBackFace = { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
+
+        CollectionAssert.AreEqual(expectedTopFace, state.GetFace(CubeFace.Top));
+        CollectionAssert.AreEqual(expectedBottomFace, state.GetFace(CubeFace.Bottom));
+        CollectionAssert.AreEqual(expectedLeftFace, state.GetFace(CubeFace.Left));
+        CollectionAssert.AreEqual(expectedRightFace, state.GetFace(CubeFace.Right));
+        CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
+        CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
+    }
 }

--- a/Solution/TestSuite/CubePuzzleTests.cs
+++ b/Solution/TestSuite/CubePuzzleTests.cs
@@ -1,0 +1,32 @@
+namespace TestSuite;
+using LibNetCube;
+
+[TestClass]
+public class CubePuzzleTests
+{
+    [TestMethod]
+    public void TestReset()
+    {
+        CubePuzzle puzzle = new CubePuzzle();
+
+        CubeMove move = CubeMove.U;
+        puzzle.PerformMove(move);
+
+        puzzle.Reset();
+        CubeState state = puzzle.GetState();
+
+        int[,] expectedTopFace = { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
+        int[,] expectedBottomFace = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+        int[,] expectedLeftFace = { { 3, 3, 3 }, { 3, 3, 3 }, { 3, 3, 3 } };
+        int[,] expectedRightFace = { { 4, 4, 4 }, { 4, 4, 4 }, { 4, 4, 4 } };
+        int[,] expectedFrontFace = { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
+        int[,] expectedBackFace = { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
+
+        CollectionAssert.AreEqual(expectedTopFace, state.GetFace(CubeFace.Top));
+        CollectionAssert.AreEqual(expectedBottomFace, state.GetFace(CubeFace.Bottom));
+        CollectionAssert.AreEqual(expectedLeftFace, state.GetFace(CubeFace.Left));
+        CollectionAssert.AreEqual(expectedRightFace, state.GetFace(CubeFace.Right));
+        CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
+        CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
+    }
+}

--- a/Solution/TestSuite/CubePuzzleTests.cs
+++ b/Solution/TestSuite/CubePuzzleTests.cs
@@ -29,28 +29,4 @@ public class CubePuzzleTests
         CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
         CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
     }
-
-    [TestMethod]
-    public void TestResetWithoutAnyMoves()
-    {
-        CubePuzzle puzzle = new CubePuzzle();
-
-        puzzle.Reset();
-        CubeState state = puzzle.GetState();
-
-        int[,] expectedTopFace = { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
-        int[,] expectedBottomFace = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
-        int[,] expectedLeftFace = { { 3, 3, 3 }, { 3, 3, 3 }, { 3, 3, 3 } };
-        int[,] expectedRightFace = { { 4, 4, 4 }, { 4, 4, 4 }, { 4, 4, 4 } };
-        int[,] expectedFrontFace = { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
-        int[,] expectedBackFace = { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
-
-        CollectionAssert.AreEqual(expectedTopFace, state.GetFace(CubeFace.Top));
-        CollectionAssert.AreEqual(expectedBottomFace, state.GetFace(CubeFace.Bottom));
-        CollectionAssert.AreEqual(expectedLeftFace, state.GetFace(CubeFace.Left));
-        CollectionAssert.AreEqual(expectedRightFace, state.GetFace(CubeFace.Right));
-        CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
-        CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
-    }
-
 }

--- a/Solution/TestSuite/CubePuzzleTests.cs
+++ b/Solution/TestSuite/CubePuzzleTests.cs
@@ -52,4 +52,31 @@ public class CubePuzzleTests
         CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
         CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
     }
+
+    [TestMethod]
+    public void TestResetAfterMultipleMoves()
+    {
+        CubePuzzle puzzle = new CubePuzzle();
+
+        puzzle.PerformMove(CubeMove.U);
+        puzzle.PerformMove(CubeMove.R);
+        puzzle.PerformMove(CubeMove.F);
+
+        puzzle.Reset();
+        CubeState state = puzzle.GetState();
+
+        int[,] expectedTopFace = { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
+        int[,] expectedBottomFace = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+        int[,] expectedLeftFace = { { 3, 3, 3 }, { 3, 3, 3 }, { 3, 3, 3 } };
+        int[,] expectedRightFace = { { 4, 4, 4 }, { 4, 4, 4 }, { 4, 4, 4 } };
+        int[,] expectedFrontFace = { { 2, 2, 2 }, { 2, 2, 2 }, { 2, 2, 2 } };
+        int[,] expectedBackFace = { { 5, 5, 5 }, { 5, 5, 5 }, { 5, 5, 5 } };
+
+        CollectionAssert.AreEqual(expectedTopFace, state.GetFace(CubeFace.Top));
+        CollectionAssert.AreEqual(expectedBottomFace, state.GetFace(CubeFace.Bottom));
+        CollectionAssert.AreEqual(expectedLeftFace, state.GetFace(CubeFace.Left));
+        CollectionAssert.AreEqual(expectedRightFace, state.GetFace(CubeFace.Right));
+        CollectionAssert.AreEqual(expectedFrontFace, state.GetFace(CubeFace.Front));
+        CollectionAssert.AreEqual(expectedBackFace, state.GetFace(CubeFace.Back));
+    }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/18e17c5a-3861-4bab-bd34-13b728735bc8)
_CubePuzzle.cs Line 16-25_

Sets the member variables holding the states of the cube to their default values.

![image](https://github.com/user-attachments/assets/9ef7b840-1fe2-4441-831c-1052c9389ec5)
_CubeController.cs Line 17-23_

Calls the reset method in CubePuzzle.cs so that the API can reset the cube state to its default values.
